### PR TITLE
fix: raise ValueError instead of string for unsupported providers

### DIFF
--- a/sandshrew/base_tool.py
+++ b/sandshrew/base_tool.py
@@ -76,7 +76,7 @@ class BaseTool:
             case Provider.OPENAI:
                 return OpenAIUtils.get_tool_description(name, description, params)
             case _:
-                raise f"Unsupported provider {provider}"
+                raise ValueError(f"Unsupported provider: {provider}")
 
     def _extract_parameters(self) -> Dict[str, Any]:
         """Extract parameters from function signature, skipping injected state."""


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

Changes : Fixed a bug in get_tool_description() where a string was being raised instead of a proper exception when an unsupported provider is used.